### PR TITLE
Clarify canonical cost-of-manufacturing context

### DIFF
--- a/docs/raw/cost-of-manufacturing-offering-context.md
+++ b/docs/raw/cost-of-manufacturing-offering-context.md
@@ -10,6 +10,8 @@
 
 ## Overview
 
+**Canonical scope**: This document is the authoritative source for cost-of-manufacturing context, decisions, and vendor inventories. For the original intake narrative and broader economics planning brief, reference `/docs/raw/economics-cost-structure-initial-context.md`; summarize only major changes back there to keep the two files in sync.
+
 This document provides comprehensive context for understanding the cost structure and economics of manufacturing Reg A+ offerings for small balance commercial real estate investments. This context supports the ongoing work on LEG-63 "Collect Cost of Manufacturing an Offering Inputs" and related economic modeling.
 
 ## Business Model Context

--- a/docs/raw/economics-cost-structure-initial-context.md
+++ b/docs/raw/economics-cost-structure-initial-context.md
@@ -5,7 +5,7 @@ My notes are below. I want to start rigorously organizing these throughts into a
 Review the below. I ultimately want to use chatGPT or cursor to help manage my implementation plan , research, and documentation. My company operates out of linear, and I would like to plan there, but through the use of an MCP or ChatGPT connector. I have not tried this before.
 Here are my highest priorities:
 
-- Cost of Manufacturing and Offering
+- Cost of Manufacturing and Offering _(refer to `/docs/raw/cost-of-manufacturing-offering-context.md` for the authoritative breakdown and live updates)_
 - Update and clean up all the pricing proposals and contracts into a board-quality financial model.
 - Economics and legal structure decision, based on cost, scalability, and viability of the investment platform to SMBs, my company, and retail investors
 - Determine minimum check size
@@ -85,6 +85,7 @@ Here are my highest priorities:
   </context-input>
 
 <response>
+**Canonical cost-of-manufacturing reference**: Detailed, living documentation for cost-of-manufacturing analysis now lives in `/docs/raw/cost-of-manufacturing-offering-context.md`. Maintain vendor costs, structural comparisons, and decision logs there and summarize only key updates in this intake narrative.
 0) How we’ll collaborate (options you can approve “as‑is” or mix & match)
 Option A — “Lean model first” (fastest path to a board‑quality model)
 


### PR DESCRIPTION
## Summary
- designate `/docs/raw/cost-of-manufacturing-offering-context.md` as the canonical source for cost-of-manufacturing context while pointing back to the broader economics intake brief
- update the economics intake narrative to reference the canonical cost-of-manufacturing document for authoritative details

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddfd43d26c83308d7ebdda731dc4aa